### PR TITLE
Make git clone base URL configurable to enable full offline builds.

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,7 +1,0 @@
-{deps, [
-    {lager, ".*", {git, "https://git-wip-us.apache.org/repos/asf/couchdb-lager.git", {branch, "master"}}}
-]}.
-
-{erl_opts, [debug_info, {parse_transform, lager_transform}]}.
-
-

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -1,0 +1,15 @@
+ASF = "https://git-wip-us.apache.org/repos/asf/".
+
+BaseUrl = case os:getenv("COUCH_GIT_BASE_URL") of
+  false -> ASF;
+  [] -> ASF;
+  Else ->
+    Else
+end.
+
+[
+  {deps, [
+      {lager, ".*", {git, BaseUrl ++ "couchdb-lager.git", {branch, "master"}}}
+  ]},
+  {erl_opts, [debug_info, {parse_transform, lager_transform}]}
+].


### PR DESCRIPTION
This is a first stab. I tried using Rebar's deps_dir as per
https://github.com/rebar/rebar/wiki/Dynamic-configuration
but I couldn't get it to recognise paths vs. URLs. Still
there might be a better way.

The eventual goal would be to have a full mirror of all repos
locally and being able to set the dep src for all CouchDB
dependencies via an environment variable. It is simple
enough for the main couchdb repo, but some modules, like
couch_log here define their own dependencies and they should
pick up the local dep src as well.

So yeah, weaving my hands a little, but wanted to throw this
into the ring for discussion. Let me know what you think and
how this can be done better :)

Thanks!
