### PR TITLE
perf: add function to use io lists

### DIFF
--- a/src/couch_log.erl
+++ b/src/couch_log.erl
@@ -14,6 +14,10 @@
 
 -export([debug/2, info/2, notice/2, warning/2, error/2, critical/2, alert/2, emergency/2]).
 
+% non formatting functions
+-export([notice/1]).
+
+
 debug(Fmt, Args) ->
     catch couch_stats:increment_counter([couch_log, level, debug]),
     lager:debug(Fmt, Args).
@@ -25,6 +29,9 @@ info(Fmt, Args) ->
 notice(Fmt, Args) ->
     catch couch_stats:increment_counter([couch_log, level, notice]),
     lager:notice(Fmt, Args).
+notice(Msg) ->
+    catch couch_stats:increment_counter([couch_log, level, notice]),
+    lager:notice(Msg).
 
 warning(Fmt, Args) ->
     catch couch_stats:increment_counter([couch_log, level, warning]),


### PR DESCRIPTION
we are avoiding lagers formatting here which happens before it
asynchronously dispatches the event.

for a /get on a document this increases perfomance ~4% and should
apply to all http requests.

PRs:
https://github.com/apache/couchdb-couch-log/pull/2
https://github.com/apache/couchdb-couch/pull/57