### PR TITLE
Convert couch_log into pluggable logger interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /ebin
+.eunit
+.rebar

--- a/rebar.config
+++ b/rebar.config
@@ -1,0 +1,15 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+{deps, [
+    {meck, ".*", {git, "https://git-wip-us.apache.org/repos/asf/couchdb-meck.git", {tag, "0.8.2"}}}
+]}.

--- a/rebar.config
+++ b/rebar.config
@@ -1,7 +1,0 @@
-{deps, [
-    {lager, ".*", {git, "https://git-wip-us.apache.org/repos/asf/couchdb-lager.git", {branch, "master"}}}
-]}.
-
-{erl_opts, [debug_info, {parse_transform, lager_transform}]}.
-
-

--- a/src/couch_log.app.src
+++ b/src/couch_log.app.src
@@ -15,5 +15,6 @@
     {vsn, git},
     {modules, [couch_log]},
     {registered, []},
-    {applications, [kernel, stdlib, lager]}
+    {applications, [kernel, stdlib]},
+    {env, [{backend, couch_log_stderr}]}
 ]}.

--- a/src/couch_log.app.src.script
+++ b/src/couch_log.app.src.script
@@ -10,11 +10,33 @@
 % License for the specific language governing permissions and limitations under
 % the License.
 
+CouchConfig = case filelib:is_file(os:getenv("COUCHDB_CONFIG")) of
+    true ->
+        {ok, Result} = file:consult(os:getenv("COUCHDB_CONFIG")),
+        Result;
+    false ->
+        []
+end.
+
+Backend = case lists:keyfind(couch_log_backend, 1, CouchConfig) of
+    {couch_log_backend, Backend0} ->
+        Backend0;
+    false ->
+        couch_log_stderr
+end.
+
+BackendApps = case lists:keyfind(couch_log_backend_apps, 1, CouchConfig) of
+    {couch_log_backend_apps, Apps} ->
+        Apps;
+    false ->
+        []
+end.
+
 {application, couch_log, [
     {description, "CouchDB Log API"},
     {vsn, git},
     {modules, [couch_log]},
     {registered, []},
-    {applications, [kernel, stdlib]},
-    {env, [{backend, couch_log_stderr}]}
+    {applications, [kernel, stdlib] ++ BackendApps},
+    {env, [{backend, Backend}]}
 ]}.

--- a/src/couch_log.erl
+++ b/src/couch_log.erl
@@ -15,38 +15,63 @@
 -export([debug/2, info/2, notice/2, warning/2, error/2, critical/2, alert/2, emergency/2]).
 -export([set_level/1]).
 
+-export([behaviour_info/1]).
+
+behaviour_info(callbacks) ->
+    [{debug, 2}, {info, 2}, {notice, 2}, {warning, 2},
+    {error, 2}, {critical, 2}, {alert, 2}, {set_level, 1}];
+behaviour_info(_) ->
+    undefined.
+
 debug(Fmt, Args) ->
+    {ok, Backend} = get_backend(),
     catch couch_stats:increment_counter([couch_log, level, debug]),
-    lager:debug(Fmt, Args).
+    Backend:debug(Fmt, Args).
 
 info(Fmt, Args) ->
+    {ok, Backend} = get_backend(),
     catch couch_stats:increment_counter([couch_log, level, info]),
-    lager:info(Fmt, Args).
+    Backend:info(Fmt, Args).
 
 notice(Fmt, Args) ->
+    {ok, Backend} = get_backend(),
     catch couch_stats:increment_counter([couch_log, level, notice]),
-    lager:notice(Fmt, Args).
+    Backend:notice(Fmt, Args).
 
 warning(Fmt, Args) ->
+    {ok, Backend} = get_backend(),
     catch couch_stats:increment_counter([couch_log, level, warning]),
-    lager:warning(Fmt, Args).
+    Backend:warning(Fmt, Args).
 
 error(Fmt, Args) ->
+    {ok, Backend} = get_backend(),
     catch couch_stats:increment_counter([couch_log, level, 'error']),
-    lager:error(Fmt, Args).
+    Backend:error(Fmt, Args).
 
 critical(Fmt, Args) ->
+    {ok, Backend} = get_backend(),
     catch couch_stats:increment_counter([couch_log, level, critical]),
-    lager:critical(Fmt, Args).
+    Backend:critical(Fmt, Args).
 
 alert(Fmt, Args) ->
+    {ok, Backend} = get_backend(),
     catch couch_stats:increment_counter([couch_log, level, alert]),
-    lager:alert(Fmt, Args).
+    Backend:alert(Fmt, Args).
 
 emergency(Fmt, Args) ->
+    {ok, Backend} = get_backend(),
     catch couch_stats:increment_counter([couch_log, level, emergency]),
-    lager:emergency(Fmt, Args).
+    Backend:emergency(Fmt, Args).
 
 set_level(Level) ->
-    {ok, Handlers} = application:get_env(lager, handlers),
-    [lager:set_loglevel(Handler, Level) || {Handler, _} <- Handlers].
+    {ok, Backend} = application:get_env(?MODULE, backend),
+    Backend:set_level(Level).
+
+get_backend() ->
+    case application:get_env(?MODULE, backend) of
+        undefined ->
+            ok = application:load(?MODULE),
+            get_backend();
+        {ok, Backend} ->
+            {ok, Backend}
+    end.

--- a/src/couch_log.erl
+++ b/src/couch_log.erl
@@ -77,19 +77,12 @@ emergency(Fmt, Args) ->
 
 -spec set_level(atom()) -> ok.
 set_level(Level) ->
-    {ok, Backend} = application:get_env(?MODULE, backend),
+    {ok, Backend} = get_backend(),
     Backend:set_level(Level).
 
 -spec get_backend() -> {ok, atom()}.
 get_backend() ->
-    case application:get_env(?MODULE, backend) of
-        undefined ->
-            ok = application:load(?MODULE),
-            get_backend();
-        {ok, Backend} ->
-            {ok, Backend}
-    end.
-
+    application:get_env(?MODULE, backend).
 
 -ifdef(TEST).
 

--- a/src/couch_log.erl
+++ b/src/couch_log.erl
@@ -12,6 +12,10 @@
 
 -module(couch_log).
 
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+-endif.
+
 -export([debug/2, info/2, notice/2, warning/2, error/2, critical/2, alert/2, emergency/2]).
 -export([set_level/1]).
 
@@ -23,50 +27,60 @@ behaviour_info(callbacks) ->
 behaviour_info(_) ->
     undefined.
 
+-spec debug(string(), list()) -> ok.
 debug(Fmt, Args) ->
     {ok, Backend} = get_backend(),
     catch couch_stats:increment_counter([couch_log, level, debug]),
     Backend:debug(Fmt, Args).
 
+-spec info(string(), list()) -> ok.
 info(Fmt, Args) ->
     {ok, Backend} = get_backend(),
     catch couch_stats:increment_counter([couch_log, level, info]),
     Backend:info(Fmt, Args).
 
+-spec notice(string(), list()) -> ok.
 notice(Fmt, Args) ->
     {ok, Backend} = get_backend(),
     catch couch_stats:increment_counter([couch_log, level, notice]),
     Backend:notice(Fmt, Args).
 
+-spec warning(string(), list()) -> ok.
 warning(Fmt, Args) ->
     {ok, Backend} = get_backend(),
     catch couch_stats:increment_counter([couch_log, level, warning]),
     Backend:warning(Fmt, Args).
 
+-spec error(string(), list()) -> ok.
 error(Fmt, Args) ->
     {ok, Backend} = get_backend(),
     catch couch_stats:increment_counter([couch_log, level, 'error']),
     Backend:error(Fmt, Args).
 
+-spec critical(string(), list()) -> ok.
 critical(Fmt, Args) ->
     {ok, Backend} = get_backend(),
     catch couch_stats:increment_counter([couch_log, level, critical]),
     Backend:critical(Fmt, Args).
 
+-spec alert(string(), list()) -> ok.
 alert(Fmt, Args) ->
     {ok, Backend} = get_backend(),
     catch couch_stats:increment_counter([couch_log, level, alert]),
     Backend:alert(Fmt, Args).
 
+-spec emergency(string(), list()) -> ok.
 emergency(Fmt, Args) ->
     {ok, Backend} = get_backend(),
     catch couch_stats:increment_counter([couch_log, level, emergency]),
     Backend:emergency(Fmt, Args).
 
+-spec set_level(atom()) -> ok.
 set_level(Level) ->
     {ok, Backend} = application:get_env(?MODULE, backend),
     Backend:set_level(Level).
 
+-spec get_backend() -> {ok, atom()}.
 get_backend() ->
     case application:get_env(?MODULE, backend) of
         undefined ->
@@ -75,3 +89,34 @@ get_backend() ->
         {ok, Backend} ->
             {ok, Backend}
     end.
+
+
+-ifdef(TEST).
+
+callbacks_test_() ->
+    {setup,
+        fun setup/0,
+        fun cleanup/1,
+        [
+            ?_assertEqual({ok, couch_log_stderr}, get_backend()),
+            ?_assertEqual(ok, couch_log:debug("message", [])),
+            ?_assertEqual(ok, couch_log:info("message", [])),
+            ?_assertEqual(ok, couch_log:notice("message", [])),
+            ?_assertEqual(ok, couch_log:warning("message", [])),
+            ?_assertEqual(ok, couch_log:error("message", [])),
+            ?_assertEqual(ok, couch_log:critical("message", [])),
+            ?_assertEqual(ok, couch_log:alert("message", [])),
+            ?_assertEqual(ok, couch_log:emergency("message", [])),
+            ?_assertEqual(ok, couch_log:set_level(info))
+        ]
+    }.
+
+setup() ->
+    meck:new([couch_stats]),
+    meck:expect(couch_stats, increment_counter, fun(_) -> ok end),
+    application:load(?MODULE).
+
+cleanup(_) ->
+    meck:unload([couch_stats]).
+
+-endif.

--- a/src/couch_log_stderr.erl
+++ b/src/couch_log_stderr.erl
@@ -1,0 +1,57 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+-module(couch_log_stderr).
+
+-behaviour(couch_log).
+
+-export([
+    debug/2,
+    info/2,
+    notice/2,
+    warning/2,
+    error/2,
+    critical/2,
+    alert/2,
+    emergency/2,
+    set_level/1
+]).
+
+debug(Fmt, Args) ->
+    write_log("[debug] " ++ Fmt, Args).
+
+info(Fmt, Args) ->
+    write_log("[info] " ++ Fmt, Args).
+
+notice(Fmt, Args) ->
+    write_log("[notice] " ++ Fmt, Args).
+
+warning(Fmt, Args) ->
+    write_log("[warning] " ++ Fmt, Args).
+
+error(Fmt, Args) ->
+    write_log("[error] " ++ Fmt, Args).
+
+critical(Fmt, Args) ->
+    write_log("[critical] " ++ Fmt, Args).
+
+alert(Fmt, Args) ->
+    write_log("[alert] " ++ Fmt, Args).
+
+emergency(Fmt, Args) ->
+    write_log("[emergency] " ++ Fmt, Args).
+
+write_log(Fmt, Args) ->
+    io:format(standard_error, Fmt ++ "~n", Args).
+
+set_level(_) ->
+    ok.


### PR DESCRIPTION
This change converts couch_log into behaviour that allows to decouple it with lager and use CouchDB with any logging framework. The backend could be specified with couch_log application's environment variable `backed`.

The very basic logger that logs to `standard_error` included as an implementation example and fail-safe measure.
