### PR TITLE
Recognize rebar templater's list format

### DIFF
--- a/src/couch_log.app.src.script
+++ b/src/couch_log.app.src.script
@@ -26,6 +26,8 @@ Backend = case lists:keyfind(couch_log_backend, 1, CouchConfig) of
 end.
 
 BackendApps = case lists:keyfind(couch_log_backend_apps, 1, CouchConfig) of
+    {couch_log_backend_apps, {list, Apps}} ->
+        Apps;
     {couch_log_backend_apps, Apps} ->
         Apps;
     false ->


### PR DESCRIPTION
Rebar's templater uses tagged tuples to accept lists in .script files. This fix makes `couch_log.app` script to recognize this convention.