### PR TITLE
Create a custom logging backend for unit tests.

### DIFF
--- a/src/couch_log_testbackend.erl
+++ b/src/couch_log_testbackend.erl
@@ -1,0 +1,65 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+-module(couch_log_testbackend).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-behaviour(couch_log).
+
+-export([
+    debug/2,
+    info/2,
+    notice/2,
+    warning/2,
+    error/2,
+    critical/2,
+    alert/2,
+    emergency/2,
+    set_level/1
+]).
+
+debug(_Fmt, _Args) ->
+    ok.
+
+info(_Fmt, _Args) ->
+    ok.
+
+notice(_Fmt, _Args) ->
+    ok.
+
+warning(_Fmt, _Args) ->
+    ok.
+
+error(Fmt, Args) ->
+    write_log("[error] " ++ Fmt, Args).
+
+critical(Fmt, Args) ->
+    write_log("[critical] " ++ Fmt, Args).
+
+alert(Fmt, Args) ->
+    write_log("[alert] " ++ Fmt, Args).
+
+emergency(Fmt, Args) ->
+    write_log("[emergency] " ++ Fmt, Args).
+
+
+-ifdef(TEST).
+write_log(Fmt, Args) ->
+    ?debugFmt(Fmt, Args).
+-else.
+write_log(Fmt, Args) ->
+    io:format(standard_error, Fmt ++ "~n", Args).
+-endif.
+
+set_level(_) ->
+    ok.

--- a/test/couch_log_tests.erl
+++ b/test/couch_log_tests.erl
@@ -1,0 +1,70 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+-module(couch_log_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+callbacks_test_() ->
+    {setup,
+        fun setup/0,
+        fun cleanup/1,
+        [
+            ?_assertEqual({ok, couch_log_eunit}, couch_log:get_backend()),
+            ?_assertEqual(ok, couch_log:set_level(info)),
+            ?_assertEqual(ok, couch_log:debug("debug", [])),
+            ?_assertEqual(ok, couch_log:info("info", [])),
+            ?_assertEqual(ok, couch_log:notice("notice", [])),
+            ?_assertEqual(ok, couch_log:warning("warning", [])),
+            ?_assertEqual(ok, couch_log:error("error", [])),
+            ?_assertEqual(ok, couch_log:critical("critical", [])),
+            ?_assertEqual(ok, couch_log:alert("alert", [])),
+            ?_assertEqual(ok, couch_log:emergency("emergency", [])),
+            ?_assertEqual(stats_calls(), meck:history(couch_stats, self())),
+            ?_assertEqual(log_calls(), meck:history(couch_log_eunit, self()))
+        ]
+    }.
+
+setup() ->
+    meck:new([couch_stats, couch_log_eunit], [non_strict]),
+    meck:new(couch_log, [passthrough]),
+    meck:expect(couch_stats, increment_counter, 1, ok),
+    meck:expect(couch_log, get_backend, fun() -> application:get_env(couch_log, backend) end),
+    setup_couch_log_eunit(),
+    application:load(couch_log),
+    application:set_env(couch_log, backend, couch_log_eunit).
+
+cleanup(_) ->
+    meck:unload([couch_stats, couch_log_eunit, couch_log]).
+
+setup_couch_log_eunit() ->
+    meck:expect(couch_log_eunit, set_level, 1, ok),
+    Levels = [debug, info, notice, warning, error, critical, alert, emergency],
+    lists:foreach(fun(Fun) ->
+        meck:expect(couch_log_eunit, Fun, 2, ok)
+    end, Levels).
+
+stats_calls() ->
+    Levels = [debug, info, notice, warning, error, critical, alert, emergency],
+    lists:map(fun(Level) ->
+        MFA = {couch_stats, increment_counter, [[couch_log, level, Level]]},
+        {self(), MFA, ok}
+    end, Levels).
+
+log_calls() ->
+    Levels = [debug, info, notice, warning, error, critical, alert, emergency],
+    Calls = lists:map(fun(Level) ->
+        MFA = {couch_log_eunit, Level, [atom_to_list(Level),[]]},
+        {self(), MFA, ok}
+    end, Levels),
+    [{self(), {couch_log_eunit, set_level, [info]}, ok}|Calls].
+


### PR DESCRIPTION
 * Disables logging of anything below error level.

 * Backend is enabled automatically if running in test mode.

 * For couch_log's own tests, use mocking in order to bypass testing mode.

 * For mocking to work with couch_log tests, move tests to
   a separate tests/ folder.

COUCHDB-2855