### PR TITLE
Remove module_loaded check in get_backend

### DIFF
--- a/src/couch_log.erl
+++ b/src/couch_log.erl
@@ -112,11 +112,7 @@ set_level(Level) ->
 -spec get_backend() -> {ok, atom()}.
 get_backend() ->
     BackendName = "couch_log_" ++ config:get("log", "backend", "stderr"),
-    Backend = list_to_existing_atom(BackendName),  %% yes, we need crash here
-    case erlang:module_loaded(Backend) of
-        true -> {ok, Backend};
-        false -> {ok, couch_log_stderr}
-    end.
+    {ok, list_to_existing_atom(BackendName)}.
 
 -ifdef(TEST).
 


### PR DESCRIPTION
See [the JIRA ticket](https://issues.apache.org/jira/browse/COUCHDB-2968) for
the full context.

I'm not sure whether or not we're losing anything by removing the check or whether
there's another way we could fix this. /cc @kxepal 

---
When the code server loads modules dynamically,
module_loaded(Backend) will not return true until it has actually
been called. Since couch_log is the only thing that calls it, this
can result in the backend module never being loaded.

Closes COUCHDB-2968