### PR TITLE
Fix couch_log:is_active_level/1 type spec

### DIFF
--- a/src/couch_log.erl
+++ b/src/couch_log.erl
@@ -97,7 +97,7 @@ log(Level, Fmt, Args) ->
             apply(Backend, Level, [Fmt, Args])
     end.
 
--spec is_active_level(atom()) -> boolean.
+-spec is_active_level(atom()) -> boolean().
 is_active_level(Level) ->
     CurrentLevel = level_to_atom(config:get("log", "level", "notice")),
     level_integer(Level) >= level_integer(CurrentLevel).


### PR DESCRIPTION
The return value should be a `boolean()` type not an atom `boolean`