### PR TITLE
Fix dns timeout for undefined syslog host

### DIFF
--- a/src/couch_log_writer_syslog.erl
+++ b/src/couch_log_writer_syslog.erl
@@ -46,13 +46,17 @@
 init() ->
     {ok, Socket} = gen_udp:open(0),
 
-    SysLogHost = config:get("log", "syslog_host"),
-    Host = case inet:getaddr(SysLogHost, inet) of
-        {ok, Address} when SysLogHost /= undefined ->
-            Address;
-        _ ->
-            undefined
-    end,
+    Host = case config:get("log", "syslog_host") of
+        undefined ->
+            undefined;
+        SysLogHost ->
+            case inet:getaddr(SysLogHost, inet) of
+                {ok, Address} ->
+                    Address;
+                _ ->
+                    undefined
+            end
+        end,
 
     {ok, #st{
         socket = Socket,


### PR DESCRIPTION
On some platforms, inet:getaddr can take several seconds to return when
passed the undefined atom, which is the default value of "syslog_host",
and therefore the value used when running tests. On platforms where it
takes longer to return than the test is allowed to run, the
couch_log_writer_syslog_test will fail with *timed out*.

This short circuits the case when "syslog_host" is undefined, and
removes the race from the test.

COUCHDB-3340